### PR TITLE
Fix IF Alternative condition parsing (ref #5)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -197,7 +197,7 @@ func (i *Identifier) String() string {
 type IfExpression struct {
 	Token       token.Token
 	Condition   Expression
-	Consequence BlockStatement
+	Consequence *BlockStatement
 	Alternative *BlockStatement
 }
 
@@ -254,7 +254,7 @@ func (ie *IndexExpression) String() string {
 type FunctionLiteral struct {
 	Token      token.Token
 	Parameters []*Identifier
-	Body       BlockStatement
+	Body       *BlockStatement
 }
 
 func (fl *FunctionLiteral) expressionNode() {}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -61,7 +61,7 @@ func TestIfExpression_String(t *testing.T) {
 						},
 						Value: true,
 					},
-					Consequence: BlockStatement{
+					Consequence: &BlockStatement{
 						Token: token.Token{
 							Type:    token.LBRACE,
 							Literal: "{",
@@ -116,7 +116,7 @@ func TestFunctionLiteral_String(t *testing.T) {
 						Literal: "fn",
 					},
 					Parameters: []*Identifier{},
-					Body: BlockStatement{
+					Body: &BlockStatement{
 						Token: token.Token{
 							Type:    token.LBRACE,
 							Literal: "{",

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -202,7 +202,7 @@ func evalIfConditionalExpression(ifExpression *ast.IfExpression, env *object.Env
 		return evaluatedCondition
 	}
 	if isTruthy(evaluatedCondition) {
-		return Eval(&ifExpression.Consequence, env)
+		return Eval(ifExpression.Consequence, env)
 	}
 	if ifExpression.Alternative != nil {
 		return Eval(ifExpression.Alternative, env)

--- a/object/function.go
+++ b/object/function.go
@@ -8,11 +8,11 @@ import (
 
 type Function struct {
 	Parameters []*ast.Identifier
-	Body       ast.BlockStatement
+	Body       *ast.BlockStatement
 	Env        *Environment
 }
 
-func NewFunction(params []*ast.Identifier, body ast.BlockStatement, env *Environment) *Function {
+func NewFunction(params []*ast.Identifier, body *ast.BlockStatement, env *Environment) *Function {
 	return &Function{Parameters: params, Body: body, Env: env}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -317,8 +317,8 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 	return exp
 }
 
-func (p *Parser) parseBlockStatement() ast.BlockStatement {
-	bs := ast.BlockStatement{Token: p.currentToken}
+func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	bs := &ast.BlockStatement{Token: p.currentToken}
 	bs.Statements = []ast.Statement{}
 
 	p.nextToken()
@@ -362,10 +362,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 			return nil
 		}
 
-		stmt := p.parseBlockStatement()
-		ifExp.Alternative = &stmt
-
-		p.nextToken()
+		ifExp.Alternative = p.parseBlockStatement()
 	}
 
 	return ifExp

--- a/parser/parser_conditions_test.go
+++ b/parser/parser_conditions_test.go
@@ -1,0 +1,20 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestElseBlockStatement(t *testing.T) {
+	// Ref: https://github.com/sonirico/node.go/issues/5
+
+	// Ensures that a conditional expression within other block statements
+	// are correctly parsed
+	payload := `
+		if (true) {
+			if (true) {
+			} else {
+			}
+		}
+	`
+	ParseTesting(t, payload)
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -599,7 +599,7 @@ func TestIfExpression(t *testing.T) {
 
 func TestIfWithElseExpression(t *testing.T) {
 	code := `
-		if (true) {z} else {1}'
+		if (true) {z} else {1}
 	`
 	lex := lexer.New(code)
 	par := New(lex)


### PR DESCRIPTION
This commit removes one token roll-up made in
"parseIfExpression" regarding alternative conditions. This
extra call created a situation where the "EOF" token
prematurely appeared, making the whole parser get crazy.

Additionally, use pointers for both BlockStatements and Alternative
expression on conditional nodes.